### PR TITLE
chore: use HTTPS package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "main": "./lib",
   "repository": {
     "type": "git",
-    "url": "http://github.com/xinbenlv/passport-weibo.git"
+    "url": "https://github.com/xinbenlv/passport-weibo.git"
   },
   "bugs": {
-    "url": "http://github.com/xinbenlv/passport-weibo/issues"
+    "url": "https://github.com/xinbenlv/passport-weibo/issues"
   },
   "author": {
     "name": "Zainan Victor Zhou",


### PR DESCRIPTION
Updates package metadata to use HTTPS GitHub URLs instead of legacy unauthenticated URLs.

Validation:
- `git diff --check`
- parsed `package.json` with Node.js